### PR TITLE
Fix GFX_DIMENSIONS_RECT_FROM_LEFT_EDGE undefined reference

### DIFF
--- a/red_coin_value_dist.patch
+++ b/red_coin_value_dist.patch
@@ -1,8 +1,16 @@
 diff --git a/src/game/object_list_processor.c b/src/game/object_list_processor.c
-index b8a454c..0316b26 100644
+index 828e3b5..7c8f7d2 100644
 --- a/src/game/object_list_processor.c
 +++ b/src/game/object_list_processor.c
-@@ -263,6 +263,15 @@ void spawn_particle(u32 activeParticleFlag, s16 model, const BehaviorScript *beh
+@@ -9,6 +9,7 @@
+ #include "engine/graph_node.h"
+ #include "engine/surface_collision.h"
+ #include "engine/surface_load.h"
++#include "gfx_dimensions.h"
+ #include "interaction.h"
+ #include "level_update.h"
+ #include "mario.h"
+@@ -263,6 +264,15 @@ void spawn_particle(u32 activeParticleFlag, s16 model, const BehaviorScript *beh
      }
  }
  
@@ -18,7 +26,7 @@ index b8a454c..0316b26 100644
  /**
   * Mario's primary behavior update function.
   */
-@@ -286,6 +295,8 @@ void bhv_mario_update(void) {
+@@ -286,6 +296,8 @@ void bhv_mario_update(void) {
  
          i++;
      }


### PR DESCRIPTION
Adds missing gfx_dimensions.h include to the object_list_processor.c patch.
Tested both apply_patch.sh and git apply.